### PR TITLE
Import Foundation in Retry.swift for pow

### DIFF
--- a/Sources/GPT/Retry.swift
+++ b/Sources/GPT/Retry.swift
@@ -7,6 +7,7 @@
 
 import SynchronizationKit
 import LazyKit
+import Foundation
 
 extension RetryAdviser {
     // in nano seconds


### PR DESCRIPTION
Added the Foundation import to Retry.swift to ensure necessary types and functionality are available.