### PR TITLE
Remove extraBody support from OpenAI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+Behavior changes:
+
+- The official OpenAI provider no longer forwards `Prompt.extraBody`; `extraBody` remains supported for OpenAI-compatible providers.
+
 ## 0.9.0 (2026-04-15)
 
 Feature enhancements:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ A Swift package for interacting with Large Language Models (LLMs) from various p
 - **Automatic Retries**: Built-in retry logic with configurable strategies to handle transient network issues or model failures.
 - **Type-Safe**: Leverages Swift's type system to ensure correctness and provide a great developer experience.
 
+### Provider-specific request fields
+
+`Prompt.extraBody` is supported only by OpenAI-compatible providers for
+provider-specific request fields. The official OpenAI provider ignores
+`extraBody`.
+
 ## Installation
 
 Add `swift-gpt` as a dependency to your `Package.swift` file:

--- a/Sources/GPT/GPT.docc/Providers.md
+++ b/Sources/GPT/GPT.docc/Providers.md
@@ -29,6 +29,9 @@ let openAIProvider = LLMProviderConfiguration(
 )
 ```
 
+The official OpenAI provider sends only the supported OpenAI request fields.
+`Prompt.extraBody` is ignored for this provider.
+
 ### OpenAI-Compatible
 
 For an OpenAI-compatible provider, you would use the `.OpenAICompatible` type and provide the appropriate URL.
@@ -43,6 +46,10 @@ let localLLMProvider = LLMProviderConfiguration(
     apiURL: "http://localhost:8080"
 )
 ```
+
+OpenAI-compatible providers support `Prompt.extraBody` for provider-specific
+request body fields. These fields are encoded at the top level of the request
+body.
 
 ### Gemini
 

--- a/Sources/GPT/Provider/OpenAI/Convert+OpenAI.swift
+++ b/Sources/GPT/Provider/OpenAI/Convert+OpenAI.swift
@@ -191,8 +191,7 @@ extension OpenAIModelReponseRequest {
             tools: nil,
             topP: generationControl?.topP,
             truncation: nil,
-            user: nil, // TODO: provide session ID or user ID
-            extraBody: prompt.extraBody ?? [:]
+            user: nil // TODO: provide session ID or user ID
         )
     }
 }

--- a/Sources/GPT/Provider/Vendor/OpenAI/OpenAIModelReponseRequest.swift
+++ b/Sources/GPT/Provider/Vendor/OpenAI/OpenAIModelReponseRequest.swift
@@ -2095,10 +2095,8 @@ public struct OpenAIModelReponseRequest: Codable, Sendable {
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     /// [Learn more](https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids).
     public let user: String?
-
-    public let extraBody: [String: DynamicJSON.JSON]
     
-    public init(input: OpenAIModelReponseRequestInput, model: String, background: Bool?, include: [ModelReponseRequestAdditionalData]?, instructions: String?, maxOutputTokens: Int?, metadata: [String : String]?, parallelToolCalls: Bool?, previousResponseId: String?, reasoning: OpenAIModelReponseRequestResoning?, store: Bool?, stream: Bool?, temperature: Double?, text: openAIModelReponseRequestTextConfiguration?, toolChoice: OpenAIModelReponseRequestToolChoice?, tools: [OpenAIModelReponseRequestTool]?, topP: Double?, truncation: OpenAIModelReponseRequestTruncation?, user: String?, extraBody: [String : DynamicJSON.JSON] = [:]) {
+    public init(input: OpenAIModelReponseRequestInput, model: String, background: Bool?, include: [ModelReponseRequestAdditionalData]?, instructions: String?, maxOutputTokens: Int?, metadata: [String : String]?, parallelToolCalls: Bool?, previousResponseId: String?, reasoning: OpenAIModelReponseRequestResoning?, store: Bool?, stream: Bool?, temperature: Double?, text: openAIModelReponseRequestTextConfiguration?, toolChoice: OpenAIModelReponseRequestToolChoice?, tools: [OpenAIModelReponseRequestTool]?, topP: Double?, truncation: OpenAIModelReponseRequestTruncation?, user: String?) {
         self.input = input
         self.model = model
         self.background = background
@@ -2118,7 +2116,6 @@ public struct OpenAIModelReponseRequest: Codable, Sendable {
         self.topP = topP
         self.truncation = truncation
         self.user = user
-        self.extraBody = extraBody
     }
     
     public init(from decoder: any Decoder) throws {
@@ -2143,17 +2140,6 @@ public struct OpenAIModelReponseRequest: Codable, Sendable {
         self.topP = try container.decodeIfPresent(Double.self, forKey: .topP)
         self.truncation = try container.decodeIfPresent(OpenAIModelReponseRequestTruncation.self, forKey: .truncation)
         self.user = try container.decodeIfPresent(String.self, forKey: .user)
-        
-        let extraKeys = Set(container.allKeys).subtracting(CodingKeys.allKeys)
-        var extraBody: [String: JSON] = [:]
-        
-        for key in extraKeys {
-            if let value = try? container.decodeIfPresent(JSON.self, forKey: key) {
-                extraBody[key.stringValue] = value
-            }
-        }
-        
-        self.extraBody = extraBody
     }
     
     public func encode(to encoder: any Encoder) throws {
@@ -2178,13 +2164,6 @@ public struct OpenAIModelReponseRequest: Codable, Sendable {
         try container.encodeIfPresent(self.topP, forKey: .topP)
         try container.encodeIfPresent(self.truncation, forKey: .truncation)
         try container.encodeIfPresent(self.user, forKey: .user)
-        
-        for (key, body) in extraBody {
-            guard let codingKey = CodingKeys(stringValue: key) else {
-                continue
-            }
-            try container.encodeIfPresent(body, forKey: codingKey)
-        }
     }
 }
 
@@ -2207,10 +2186,6 @@ extension OpenAIModelReponseRequest {
 }
 
 extension OpenAIModelReponseRequest.CodingKeys {
-    static let allKeys: [Self] = [
-        .input, .model, .background, .include, .instructions, .maxOutputTokens, .metadata, .parallelToolCalls, .previousResponseId, .reasoning, .store, .stream, .temperature, .text, .toolChoice, .tools, .topP, .user
-    ]
-    
     static let input = Self(stringValue: "input")!
     static let model = Self(stringValue: "model")!
     static let background = Self(stringValue: "background")!

--- a/Sources/GPT/Public/Prompt.swift
+++ b/Sources/GPT/Public/Prompt.swift
@@ -245,6 +245,11 @@ public struct Prompt: Sendable {
     /// The sequence of inputs that make up the prompt.
     public let inputs: [Input]
 
+    /// Additional provider-specific request body fields.
+    ///
+    /// This is forwarded by OpenAI-compatible providers only. The official
+    /// OpenAI provider ignores this value and sends only the supported OpenAI
+    /// request fields.
     public let extraBody: [String: DynamicJSON.JSON]?
 
     /// A flag indicating whether to use streaming for the response.
@@ -266,6 +271,8 @@ public struct Prompt: Sendable {
     ///   - conversationID: An optional identifier for the current conversation.
     ///   - instructions: System-level instructions for the model.
     ///   - inputs: The sequence of inputs for the prompt.
+    ///   - extraBody: Additional provider-specific request body fields for
+    ///     OpenAI-compatible providers. Ignored by the official OpenAI provider.
     ///   - stream: A flag indicating whether to use streaming.
     ///   - generation: Controls the generation process.
     ///   - context: Controls the context of the prompt.

--- a/Tests/GPTTests/ProviderRequestBodyTests.swift
+++ b/Tests/GPTTests/ProviderRequestBodyTests.swift
@@ -12,7 +12,7 @@ import LazyKit
 import DynamicJSON
 
 @Test
-func testOpenAIRequestBodyWithExtraBody() throws {
+func testOpenAIRequestBodyDoesNotSupportExtraBody() throws {
 
     let request = OpenAIModelReponseRequest(input: .text("Foo"),
                                             model: "Bar",
@@ -32,12 +32,9 @@ func testOpenAIRequestBodyWithExtraBody() throws {
                                             tools: nil,
                                             topP: nil,
                                             truncation: nil,
-                                            user: nil,
-                                            extraBody: [
-                                                "baz": ["age":69, "name":"John"]
-                                            ])
+                                            user: nil)
 
-    let str = "{\"baz\":{\"age\":69,\"name\":\"John\"},\"input\":\"Foo\",\"model\":\"Bar\"}"
+    let str = "{\"input\":\"Foo\",\"model\":\"Bar\"}"
 
     let encoder = JSONEncoder()
     encoder.outputFormatting = .sortedKeys
@@ -46,7 +43,8 @@ func testOpenAIRequestBodyWithExtraBody() throws {
 
     let decoder = JSONDecoder()
     let decoded = try decoder.decode(OpenAIModelReponseRequest.self, from: str.data(using: .utf8)!)
-    #expect(decoded.extraBody.debugDescription == request.extraBody.debugDescription)
+    let decodedData = try encoder.encode(decoded)
+    #expect(String(data: decodedData, encoding: .utf8) == str)
 
 }
 
@@ -94,13 +92,14 @@ func testOpenAICompatibleRequestBodyWithExtraBody() throws {
 
     let decoder = JSONDecoder()
     let decoded = try decoder.decode(OpenAIChatCompletionRequest.self, from: str.data(using: .utf8)!)
-    #expect(decoded.extraBody.debugDescription == request.extraBody.debugDescription)
+    let decodedData = try encoder.encode(decoded)
+    #expect(String(data: decodedData, encoding: .utf8) == str)
 
 }
 
 
 @Test
-func testOpenAIRequestBodyWithExtraBodyByAny() throws {
+func testOpenAIRequestBodyIgnoresExtraBodyByAny() throws {
 
     let str = "{\"baz\":{\"age\":69,\"name\":\"John\"},\"input\":\"Foo\",\"model\":\"Bar\"}"
     let dict: [String: Any] = [
@@ -114,11 +113,35 @@ func testOpenAIRequestBodyWithExtraBodyByAny() throws {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .sortedKeys
     let encoded = try encoder.encode(request)
-    #expect(String(data: encoded, encoding: .utf8) == str)
+    #expect(String(data: encoded, encoding: .utf8) == "{\"input\":\"Foo\",\"model\":\"Bar\"}")
 
     let decoder = JSONDecoder()
     let decoded = try decoder.decode(OpenAIModelReponseRequest.self, from: str.data(using: .utf8)!)
-    #expect(decoded.extraBody.debugDescription == request.extraBody.debugDescription)
+    let decodedData = try encoder.encode(decoded)
+    #expect(String(data: decodedData, encoding: .utf8) == "{\"input\":\"Foo\",\"model\":\"Bar\"}")
+}
+
+@Test
+func testOpenAIProviderIgnoresPromptExtraBody() throws {
+    let prompt = Prompt(
+        inputs: [
+            .text(.init(role: .user, content: "Foo"))
+        ],
+        extraBody: [
+            "baz": ["age": 69, "name": "John"]
+        ],
+        stream: false
+    )
+    let request = OpenAIModelReponseRequest(prompt, history: .init(), model: "Bar", stream: false)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let encoded = try encoder.encode(request)
+    let encodedString = String(data: encoded, encoding: .utf8) ?? ""
+
+    #expect(!encodedString.contains("\"baz\""))
+    #expect(!encodedString.contains("\"age\""))
+    #expect(!encodedString.contains("\"name\""))
 }
 
 @Test
@@ -140,6 +163,7 @@ func testOpenAICompatibleRequestBodyWithExtraBodyByAny() throws {
 
     let decoder = JSONDecoder()
     let decoded = try decoder.decode(OpenAIChatCompletionRequest.self, from: str.data(using: .utf8)!)
-    #expect(decoded.extraBody.debugDescription == request.extraBody.debugDescription)
+    let decodedData = try encoder.encode(decoded)
+    #expect(String(data: decodedData, encoding: .utf8) == str)
 
 }


### PR DESCRIPTION
## Summary
- Stop forwarding `Prompt.extraBody` from the official OpenAI provider.
- Remove extraBody encoding/decoding from `OpenAIModelReponseRequest`.
- Document that `extraBody` remains supported for OpenAI-compatible providers and add changelog/tests.

## Validation
- `swift test --filter ProviderRequestBodyTests`

Note: existing untracked files `gyb.py`, `model.swift.gyb`, and `models.json` were not included.